### PR TITLE
Fragment Interchange replacement in version 0.9.2-beta1

### DIFF
--- a/LiveDisplay/Activities/BackgroundSettingsActivity.cs
+++ b/LiveDisplay/Activities/BackgroundSettingsActivity.cs
@@ -88,12 +88,14 @@
         private void Pickwallpaper_Click(object sender, EventArgs e)
         {
             var button = sender as Button;
-            using AndroidX.AppCompat.App.AlertDialog.Builder builder = new AndroidX.AppCompat.App.AlertDialog.Builder(button.Context);
-            int currentwallpapersetted = int.Parse(configurationManager.RetrieveAValue(ConfigurationParameters.ChangeWallpaper, "0"));
-            builder.SetTitle(Resources.GetString(Resource.String.changewallpaper));
-            builder.SetSingleChoiceItems(new string[] { button.Context.GetString(Resource.String.blackwallpaper), button.Context.GetString(Resource.String.defaultwallpaper), button.Context.GetString(Resource.String.pickwallpaper) }, currentwallpapersetted, OnDialogClickEventArgs);
-            builder.Create();
-            builder.Show();
+            using (AndroidX.AppCompat.App.AlertDialog.Builder builder = new AndroidX.AppCompat.App.AlertDialog.Builder(button.Context))
+            {
+                int currentwallpapersetted = int.Parse(configurationManager.RetrieveAValue(ConfigurationParameters.ChangeWallpaper, "0"));
+                builder.SetTitle(Resources.GetString(Resource.String.changewallpaper));
+                builder.SetSingleChoiceItems(new string[] { button.Context.GetString(Resource.String.blackwallpaper), button.Context.GetString(Resource.String.defaultwallpaper), button.Context.GetString(Resource.String.pickwallpaper) }, currentwallpapersetted, OnDialogClickEventArgs);
+                builder.Create();
+                builder.Show();
+            }
         }
 
         private void OnDialogClickEventArgs(object sender, DialogClickEventArgs e)
@@ -332,15 +334,17 @@
                     ThreadPool.QueueUserWorkItem(m =>
                     {
                         var imagePath = configurationManager.RetrieveAValue(ConfigurationParameters.ImagePath, "");
-                        using var backgroundcopy = BitmapFactory.DecodeFile(configurationManager.RetrieveAValue(ConfigurationParameters.ImagePath, imagePath));
-                        BlurImage blurImage = new BlurImage(Application.Context);
-                        blurImage.Load(backgroundcopy).Intensity(defaultBlurLevel);
-                        var drawable = new BitmapDrawable(Resources, blurImage.GetImageBlur());
-                        RunOnUiThread(() =>
+                        using (var backgroundcopy = BitmapFactory.DecodeFile(configurationManager.RetrieveAValue(ConfigurationParameters.ImagePath, imagePath)))
                         {
-                            wallpaperPreview.Background = drawable;
-                            wallpaperPreview.Background.Alpha = defaultOpacityLevel;
-                        });
+                            BlurImage blurImage = new BlurImage(Application.Context);
+                            blurImage.Load(backgroundcopy).Intensity(defaultBlurLevel);
+                            var drawable = new BitmapDrawable(Resources, blurImage.GetImageBlur());
+                            RunOnUiThread(() =>
+                            {
+                                wallpaperPreview.Background = drawable;
+                                wallpaperPreview.Background.Alpha = defaultOpacityLevel;
+                            });
+                        }
                     });
 
                     break;

--- a/LiveDisplay/Activities/LockScreenActivity.cs
+++ b/LiveDisplay/Activities/LockScreenActivity.cs
@@ -62,18 +62,18 @@
         {
             base.OnCreate(savedInstanceState);
             SetContentView(Resource.Layout.LockScreen2);
-            ThreadPool.QueueUserWorkItem(isApphealthy =>
-            {
-                if (Checkers.IsNotificationListenerEnabled() == false || Checkers.ThisAppCanDrawOverlays() == false || Checkers.IsThisAppADeviceAdministrator() == false)
-                {
-                    RunOnUiThread(() =>
-                    {
-                        Toast.MakeText(Application.Context, "You dont have the required permissions", ToastLength.Long).Show();
-                        Finish();
-                    }
-                    );
-                }
-            });
+            //ThreadPool.QueueUserWorkItem(isApphealthy =>
+            //{
+            //    if (Checkers.IsNotificationListenerEnabled() == false || Checkers.ThisAppCanDrawOverlays() == false || Checkers.IsThisAppADeviceAdministrator() == false)
+            //    {
+            //        RunOnUiThread(() =>
+            //        {
+            //            Toast.MakeText(Application.Context, "You dont have the required permissions", ToastLength.Long).Show();
+            //            Finish();
+            //        }
+            //        );
+            //    }
+            //});
 
             //Views
             //wallpaperView = FindViewById<ImageView>(Resource.Id.wallpaper);
@@ -125,8 +125,8 @@
             //    }
             //}
 
-            //LoadAllFragments(); //initialize with the clock.
-            ReplaceFragment("clock_fragment");
+            LoadAllFragments(); //initialize with the clock.
+            //ReplaceFragment("clock_fragment");
 
             LoadConfiguration();
 
@@ -777,7 +777,17 @@
                     break;
             }
         }
-       
+
+        private void LoadAllFragments()
+        {
+            AndroidX.Fragment.App.FragmentManager fragmentManager = SupportFragmentManager;
+            AndroidX.Fragment.App.FragmentTransaction transaction = SupportFragmentManager.BeginTransaction();
+            transaction.Add(Resource.Id.WidgetPlaceholder, CreateFragment("clock_fragment"), "clock_fragment");
+            transaction.Add(Resource.Id.WidgetPlaceholder, CreateFragment("notification_fragment"), "notification_fragment");
+            transaction.Add(Resource.Id.WidgetPlaceholder, CreateFragment("music_fragment"), "music_fragment");
+            transaction.Commit();
+
+        }
         private void ReplaceFragment(string tag)
         {
             AndroidX.Fragment.App.FragmentManager fragmentManager = SupportFragmentManager;

--- a/LiveDisplay/Activities/MainActivity.cs
+++ b/LiveDisplay/Activities/MainActivity.cs
@@ -51,80 +51,92 @@
 
         private void AdminReceiver_OnDeviceAdminEnabled(object sender, bool e)
         {
-            using var adminGivenImageView = FindViewById<ImageView>(Resource.Id.deviceAccessCheckbox);
-            switch (e)
+            using (var adminGivenImageView = FindViewById<ImageView>(Resource.Id.deviceAccessCheckbox))
             {
-                case true:
-                    adminGivenImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
-                    break;
+                switch (e)
+                {
+                    case true:
+                        adminGivenImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
+                        break;
 
-                case false:
-                    adminGivenImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
-                    break;
+                    case false:
+                        adminGivenImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
+                        break;
+                }
+                ThreadPool.QueueUserWorkItem(m =>
+                {
+                    Thread.Sleep(500);
+                    IsApplicationHealthy();
+                });
             }
-            ThreadPool.QueueUserWorkItem(m => { 
-                Thread.Sleep(500);
-                IsApplicationHealthy(); });
         }
 
         private void CheckDeviceAdminAccess()
         {
-            using var adminGivenImageView = FindViewById<ImageView>(Resource.Id.deviceAccessCheckbox);
-            switch (Checkers.IsThisAppADeviceAdministrator())
+            using (var adminGivenImageView = FindViewById<ImageView>(Resource.Id.deviceAccessCheckbox))
             {
-                case true:
-                    adminGivenImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
-                    break;
+                switch (Checkers.IsThisAppADeviceAdministrator())
+                {
+                    case true:
+                        adminGivenImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
+                        break;
 
-                case false:
-                    adminGivenImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
-                    break;
+                    case false:
+                        adminGivenImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
+                        break;
+                }
             }
         }
 
         private void CheckNotificationAccess()
         {
-            using var notificationAccessGivenImageView = FindViewById<ImageView>(Resource.Id.notificationAccessCheckbox);
-            switch (Checkers.IsNotificationListenerEnabled())
+            using (var notificationAccessGivenImageView = FindViewById<ImageView>(Resource.Id.notificationAccessCheckbox))
             {
-                case true:
-                    notificationAccessGivenImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
+                switch (Checkers.IsNotificationListenerEnabled())
+                {
+                    case true:
+                        notificationAccessGivenImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
 
-                    break;
+                        break;
 
-                case false:
-                    notificationAccessGivenImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
-                    break;
+                    case false:
+                        notificationAccessGivenImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
+                        break;
+                }
             }
         }
 
         private void CheckDrawOverOtherAppsAccess()
         {
-            using var drawOverOtherAppsImageView = FindViewById<ImageView>(Resource.Id.drawOverOtherAppsAccessCheckbox);
-            if (Checkers.ThisAppCanDrawOverlays())
+            using (var drawOverOtherAppsImageView = FindViewById<ImageView>(Resource.Id.drawOverOtherAppsAccessCheckbox))
             {
-                drawOverOtherAppsImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
-            }
-            else
-            {
-                drawOverOtherAppsImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
+                if (Checkers.ThisAppCanDrawOverlays())
+                {
+                    drawOverOtherAppsImageView.SetBackgroundResource(Resource.Drawable.check_black_24);
+                }
+                else
+                {
+                    drawOverOtherAppsImageView.SetBackgroundResource(Resource.Drawable.denied_black_24);
+                }
             }
         }
 
         private void IsApplicationHealthy()
         {
-            using var accessestext = FindViewById<TextView>(Resource.Id.health);
-            if (Checkers.IsNotificationListenerEnabled() && Checkers.IsThisAppADeviceAdministrator() && Checkers.ThisAppCanDrawOverlays())
+            using (var accessestext = FindViewById<TextView>(Resource.Id.health))
             {
-                accessestext.SetText(Resource.String.accessesstatusenabled);
-                accessestext.SetTextColor(Android.Graphics.Color.Green);
-                isApplicationHealthy = true;
-            }
-            else
-            {
-                accessestext.SetText(Resource.String.accessesstatusdisabled);
-                accessestext.SetTextColor(Android.Graphics.Color.Red);
-                isApplicationHealthy = false;
+                if (Checkers.IsNotificationListenerEnabled() && Checkers.IsThisAppADeviceAdministrator() && Checkers.ThisAppCanDrawOverlays())
+                {
+                    accessestext.SetText(Resource.String.accessesstatusenabled);
+                    accessestext.SetTextColor(Android.Graphics.Color.Green);
+                    isApplicationHealthy = true;
+                }
+                else
+                {
+                    accessestext.SetText(Resource.String.accessesstatusdisabled);
+                    accessestext.SetTextColor(Android.Graphics.Color.Red);
+                    isApplicationHealthy = false;
+                }
             }
         }
 
@@ -241,8 +253,9 @@
 
         private void EnableDrawOverAccess_Click(object sender, EventArgs e)
         {
-            using var intent = new Intent(Settings.ActionManageOverlayPermission);
-            StartActivityForResult(intent, 25);
+            using (var intent = new Intent(Settings.ActionManageOverlayPermission))            
+                StartActivityForResult(intent, 25);
+            
         }
 
         private void EnableDeviceAdmin_Click(object sender, EventArgs e)

--- a/LiveDisplay/Activities/MainActivity.cs
+++ b/LiveDisplay/Activities/MainActivity.cs
@@ -175,7 +175,7 @@
 
                 case Resource.Id.action_sendtestnotification:
 
-                    if (isApplicationHealthy)
+                    if (true)
                     {
                         AwakeHelper.TurnOffScreen();
                         using (NotificationSlave slave = NotificationSlave.NotificationSlaveInstance())

--- a/LiveDisplay/Fragments/ClockFragment.cs
+++ b/LiveDisplay/Fragments/ClockFragment.cs
@@ -11,8 +11,8 @@
     using LiveDisplay.Misc;
     using LiveDisplay.Servicios;
     using LiveDisplay.Servicios.Weather;
+    using LiveDisplay.Servicios.Widget;
     using System;
-
     using Fragment = AndroidX.Fragment.App.Fragment;
 
     public class ClockFragment : Fragment
@@ -37,10 +37,13 @@
         private TextView lastupdated;
         private TextView city;
         //private LinearLayout weatherinfo;
-
+        private bool initForFirstTime=false;
+        
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
+            WidgetStatusPublisher.OnWidgetStatusChanged += WidgetStatusPublisher_OnWidgetStatusChanged;
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "ClockFragment: OnCreate", ToastLength.Long).Show());
         }
 
         private void RegisterBatteryReceiver()
@@ -75,22 +78,85 @@
             //View Events
             clock.Click += Clock_Click;
             //weatherclockcontainer.Click += Weatherclockcontainer_Click;
-            BatteryReceiver.BatteryInfoChanged += BatteryReceiver_BatteryInfoChanged;
-            ConfigurationManager configurationManager = new ConfigurationManager(AppPreferences.Default);
+            BatteryReceiver.BatteryInfoChanged += BatteryReceiver_BatteryInfoChanged;            
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "ClockFragment: OnCreateView", ToastLength.Long).Show());
+
 
             return v;
         }
 
         public override void OnResume()
         {
+            if (ConfigurationParameters.StartingWidget == "clock" && initForFirstTime == false)
+            {
+                maincontainer.Visibility = ViewStates.Visible;
+                initForFirstTime = true;
+            }
             LoadWeather();
             GrabWeatherJob.WeatherUpdated += GrabWeatherJob_WeatherUpdated;
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "ClockFragment: OnResume", ToastLength.Long).Show());
+
             base.OnResume();
         }
+
+        private void WidgetStatusPublisher_OnWidgetStatusChanged(object sender, WidgetStatusEventArgs e)
+        {
+            if (e.WidgetName == "NotificationFragment")
+            {
+                if (e.Show)
+                {
+                    if (maincontainer != null)
+                        maincontainer.Visibility = ViewStates.Invisible;
+                }
+                else
+                {
+                    if (WidgetStatusPublisher.CurrentActiveWidget == string.Empty) //If clock has a chance to show itself!
+                    {
+                        if (maincontainer != null)
+                            maincontainer.Visibility = ViewStates.Visible;
+                    }
+                    else
+                    {
+                        WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs 
+                        { 
+                            WidgetName= WidgetStatusPublisher.CurrentActiveWidget, 
+                            Active=true, //Having a Current Active Widget means it should be active by def.
+                            Show=true });
+
+                        if (maincontainer != null)
+                            maincontainer.Visibility = ViewStates.Invisible;
+
+                    }
+                }
+            }
+            else if (e.WidgetName == "MusicFragment")
+            {
+                if (e.Show)
+                {
+                    if (maincontainer != null)
+                        maincontainer.Visibility = ViewStates.Invisible;
+                }
+                else
+                {
+                    if (maincontainer != null)
+                        maincontainer.Visibility = ViewStates.Visible;
+                }
+            }
+        }
+
         public override void OnPause()
         {
             GrabWeatherJob.WeatherUpdated -= GrabWeatherJob_WeatherUpdated;
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "ClockFragment: OnPause", ToastLength.Long).Show());
+
             base.OnPause();
+        }
+        public override void OnDestroy()
+        {
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "ClockFragment: OnDestroy", ToastLength.Long).Show());
+            WidgetStatusPublisher.OnWidgetStatusChanged -= WidgetStatusPublisher_OnWidgetStatusChanged;
+            initForFirstTime = false;
+            base.OnDestroy();
         }
 
         private void GrabWeatherJob_WeatherUpdated(object sender, bool e)
@@ -141,6 +207,8 @@
             Application.Context.UnregisterReceiver(batteryReceiver);
             clock.Click -= Clock_Click;
             BatteryReceiver.BatteryInfoChanged -= BatteryReceiver_BatteryInfoChanged;
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "ClockFragment: OnDestroyView", ToastLength.Long).Show());
+
         }
 
         private void BatteryReceiver_BatteryInfoChanged(object sender, Servicios.Battery.BatteryEventArgs.BatteryChangedEventArgs e)

--- a/LiveDisplay/Fragments/ClockFragment.cs
+++ b/LiveDisplay/Fragments/ClockFragment.cs
@@ -20,6 +20,7 @@
         private readonly ConfigurationManager configurationManager = new ConfigurationManager(AppPreferences.Weather);
         private TextView date;
         private TextClock clock;
+        private LinearLayout maincontainer;
 
         //private RelativeLayout weatherclockcontainer;
         private TextView battery;
@@ -57,7 +58,7 @@
             View v = inflater.Inflate(Resource.Layout.cLock2, container, false);
             date = v.FindViewById<TextView>(Resource.Id.txtFechaLock);
             clock = v.FindViewById<TextClock>(Resource.Id.clockLock);
-            //weatherclockcontainer = v.FindViewById<RelativeLayout>(Resource.Id.weatherclockcontainer);
+            maincontainer = v.FindViewById<LinearLayout>(Resource.Id.container);
             battery = v.FindViewById<TextView>(Resource.Id.batteryLevel);
             batteryIcon = v.FindViewById<ImageView>(Resource.Id.batteryIcon);
             temperature = v.FindViewById<TextView>(Resource.Id.temperature);

--- a/LiveDisplay/Fragments/MusicFragment.cs
+++ b/LiveDisplay/Fragments/MusicFragment.cs
@@ -37,14 +37,14 @@ namespace LiveDisplay.Fragments
         public override void OnCreate(Bundle savedInstanceState)
         {
 
-            timer = new Timer
-            {
-                Interval = 1000 //1 second.
-            };
-            timer.Elapsed += Timer_Elapsed;
-            timer.Enabled = true;
+            //timer = new Timer
+            //{
+            //    Interval = 1000 //1 second.
+            //};
+            //timer.Elapsed += Timer_Elapsed;
+            //timer.Enabled = true;
 
-            WallpaperPublisher.CurrentWallpaperCleared += WallpaperPublisher_CurrentWallpaperHasBeenCleared;
+            //WallpaperPublisher.CurrentWallpaperCleared += WallpaperPublisher_CurrentWallpaperHasBeenCleared;
 
             base.OnCreate(savedInstanceState);
         }
@@ -72,21 +72,21 @@ namespace LiveDisplay.Fragments
             //View view = inflater.Inflate(Resource.Layout.MusicPlayer, container, false);
             View view = inflater.Inflate(Resource.Layout.MusicPlayer2, container, false);
 
-            BindViews(view);
-            BindViewEvents();
-            BindMusicControllerEvents();
-            timer.Elapsed += Timer_Elapsed;
+            //BindViews(view);
+            //BindViewEvents();
+            //BindMusicControllerEvents();
+            //timer.Elapsed += Timer_Elapsed;
 
-            RetrieveMediaInformation();
+            //RetrieveMediaInformation();
 
             return view;
         }
         public override void OnDestroyView()
         {
-            UnbindMusicControllerEvents();
-            WallpaperPublisher.ReleaseWallpaper();
-            timer.Elapsed -= Timer_Elapsed;
-            UnbindViewEvents();
+            //UnbindMusicControllerEvents();
+            //WallpaperPublisher.ReleaseWallpaper();
+            //timer.Elapsed -= Timer_Elapsed;
+            //UnbindViewEvents();
             base.OnDestroyView();
         }
 

--- a/LiveDisplay/Fragments/NotificationFragment.cs
+++ b/LiveDisplay/Fragments/NotificationFragment.cs
@@ -6,9 +6,11 @@ using LiveDisplay.Adapters;
 using LiveDisplay.Misc;
 using LiveDisplay.Servicios;
 using LiveDisplay.Servicios.Awake;
+using LiveDisplay.Servicios.Music;
 using LiveDisplay.Servicios.Notificaciones;
 using LiveDisplay.Servicios.Notificaciones.NotificationEventArgs;
 using LiveDisplay.Servicios.Notificaciones.NotificationStyle;
+using LiveDisplay.Servicios.Widget;
 using System;
 
 using Fragment = AndroidX.Fragment.App.Fragment;
@@ -18,40 +20,53 @@ namespace LiveDisplay.Fragments
     public class NotificationFragment : Fragment
     {
         private OpenNotification openNotification; //the current OpenNotification instance active.
-        private LinearLayout notification;
+        private LinearLayout maincontainer;
         private bool timeoutStarted = false;
         private NotificationStyleApplier styleApplier;
         private ConfigurationManager configurationManager = new ConfigurationManager(AppPreferences.Default);
-        public static event EventHandler<bool> IsWidgetVisible;
         #region Lifecycle events
 
         public override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
+            NotificationAdapterViewHolder.ItemClicked += ItemClicked;
             // Create your fragment here
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "NotifFragment: OnCreate", ToastLength.Long).Show());
+            WidgetStatusPublisher.OnWidgetStatusChanged += WidgetStatusPublisher_OnWidgetStatusChanged;
+
         }
 
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             View v = inflater.Inflate(Resource.Layout.NotificationFrag, container, false);
-            notification = v.FindViewById<LinearLayout>(Resource.Id.container);
-            //styleApplier = new NotificationStyleApplier(ref notification, this, NotificationViewType.OnLockscreen);
-            //notification.Drag += Notification_Drag;
-            //notification.Click += LlNotification_Click;
-            //NotificationAdapterViewHolder.ItemClicked += ItemClicked;
-            //NotificationAdapterViewHolder.ItemLongClicked += ItemLongClicked;
-            //CatcherHelper.NotificationPosted += CatcherHelper_NotificationPosted;
-            //CatcherHelper.NotificationRemoved += CatcherHelper_NotificationRemoved;
-            //NotificationStyleApplier.SendInlineResponseAvailabityChanged += NotificationStyleApplier_SendInlineResponseAvailabityChanged;
+            maincontainer = v.FindViewById<LinearLayout>(Resource.Id.container);
+            styleApplier = new NotificationStyleApplier(ref maincontainer, this, NotificationViewType.OnLockscreen);
+            maincontainer.Drag += Notification_Drag;
+            maincontainer.Click += LlNotification_Click;
+            NotificationAdapterViewHolder.ItemLongClicked += ItemLongClicked;
+            CatcherHelper.NotificationPosted += CatcherHelper_NotificationPosted;
+            CatcherHelper.NotificationRemoved += CatcherHelper_NotificationRemoved;
+            NotificationStyleApplier.SendInlineResponseAvailabityChanged += NotificationStyleApplier_SendInlineResponseAvailabityChanged;
 
             //if (openNotification == null) //We don't have a notification to show here, so...
             //{
             //    //...Now ask Catcher to send us the last notification posted to fill the views..
             //    NotificationSlave.NotificationSlaveInstance().RetrieveLastNotification();
             //}
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "NotifFragment: OnCreateView", ToastLength.Long).Show());
             return v;
         }
+        public override void OnPause()
+        {
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "NotifFragment: OnPause", ToastLength.Long).Show());
+            base.OnPause();
+        }
+        public override void OnResume()
+        {
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "NotifFragment: OnResume", ToastLength.Long).Show());
 
+            base.OnResume();
+        }
         private void NotificationStyleApplier_SendInlineResponseAvailabityChanged(object sender, bool e)
         {
             if (e == true)
@@ -71,11 +86,24 @@ namespace LiveDisplay.Fragments
             if (e.ShouldCauseWakeUp)
                 AwakeHelper.TurnOnScreen();
 
+            if (e.OpenNotification.RepresentsMediaPlaying())
+            {
+                MusicController.StartPlayback(e.OpenNotification.GetMediaSessionToken());
+                
+                maincontainer.Visibility = ViewStates.Invisible;
+                WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = false, WidgetName = "NotificationFragment" });
+
+                //Also start the Widget to control the playback.
+                WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "MusicFragment", Active= true });
+                return; 
+            }
+
+
             //if the current notification widget does not have a tag, let's set it.
 
-            if (notification.GetTag(Resource.String.defaulttag) == null)
+            if (maincontainer.GetTag(Resource.String.defaulttag) == null)
             {
-                notification.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
+                maincontainer.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
             }
 
             if (configurationManager.RetrieveAValue(ConfigurationParameters.TestEnabled))
@@ -93,17 +121,18 @@ namespace LiveDisplay.Fragments
                 {
                     //if updates a previous notification, let's see if first of all the notification
                     //to be updated is the same that's currently being displayed in the Notification Widget.
-                    if ((string)notification.GetTag(Resource.String.defaulttag) == openNotification.GetCustomId())
+                    if ((string)maincontainer.GetTag(Resource.String.defaulttag) == openNotification.GetCustomId())
                     {
                         //Watch out for possible memory leaks here.
                         styleApplier?.ApplyStyle(openNotification);
 
                         //let's attach a tag to the fragment in order to know which notification is this fragment showing.
-                        notification.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
+                        maincontainer.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
 
-                        if (notification.Visibility != ViewStates.Visible)
+                        if (maincontainer.Visibility != ViewStates.Visible)
                         {
-                            notification.Visibility = ViewStates.Visible;
+                            WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "NotificationFragment" });
+                            maincontainer.Visibility = ViewStates.Visible;
                             StartTimeout(false);
                         }
                     }
@@ -119,10 +148,11 @@ namespace LiveDisplay.Fragments
                 Activity.RunOnUiThread(() =>
                 {
                     styleApplier?.ApplyStyle(openNotification);
-                    notification.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
-                    if (notification.Visibility != ViewStates.Visible)
+                    maincontainer.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
+                    if (maincontainer.Visibility != ViewStates.Visible)
                     {
-                        notification.Visibility = ViewStates.Visible;
+                        WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "NotificationFragment" });
+                        maincontainer.Visibility = ViewStates.Visible;
                         StartTimeout(false);
                     }
                 });
@@ -132,13 +162,13 @@ namespace LiveDisplay.Fragments
         {
             //notification.Drag -= Notification_Drag;
             //notification.Click -= LlNotification_Click;
-            //NotificationAdapterViewHolder.ItemClicked -= ItemClicked;
             //NotificationAdapterViewHolder.ItemLongClicked -= ItemLongClicked;
             //CatcherHelper.NotificationRemoved -= CatcherHelper_NotificationRemoved;
             //CatcherHelper.NotificationPosted -= CatcherHelper_NotificationPosted;
             //NotificationStyleApplier.SendInlineResponseAvailabityChanged -= NotificationStyleApplier_SendInlineResponseAvailabityChanged;
 
             styleApplier = null;
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "NotifFragment: OnDestroyView", ToastLength.Long).Show());
 
             base.OnDestroyView();
         }
@@ -146,7 +176,23 @@ namespace LiveDisplay.Fragments
         public override void OnDestroy()
         {
             openNotification?.Dispose();
+            Activity.RunOnUiThread(() => Toast.MakeText(Context, "NotifFragment: OnDestroy", ToastLength.Long).Show());
+            NotificationAdapterViewHolder.ItemClicked -= ItemClicked;
+            WidgetStatusPublisher.OnWidgetStatusChanged -= WidgetStatusPublisher_OnWidgetStatusChanged;
+
             base.OnDestroy();
+        }
+
+        private void WidgetStatusPublisher_OnWidgetStatusChanged(object sender, WidgetStatusEventArgs e)
+        {
+            if (e.WidgetName == "MusicFragment")
+            {
+                if (e.Show == true)
+                {
+                    if (maincontainer != null)
+                        maincontainer.Visibility = ViewStates.Invisible;
+                }
+            }
         }
 
         #endregion Lifecycle events
@@ -157,11 +203,12 @@ namespace LiveDisplay.Fragments
         {
             Activity?.RunOnUiThread(() =>
             {
-                notification.Visibility = ViewStates.Gone;
+                WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = false, WidgetName = "NotificationFragment" });
+
+                maincontainer.Visibility = ViewStates.Gone;
                 //Remove tag, notification removed
                 openNotification = null;
-                notification?.SetTag(Resource.String.defaulttag, null);
-                IsWidgetVisible?.Invoke(null, false);
+                maincontainer?.SetTag(Resource.String.defaulttag, null);
             });
         }
 
@@ -169,13 +216,13 @@ namespace LiveDisplay.Fragments
         {
             Activity?.RunOnUiThread(() =>
             {
-                notification.Visibility = ViewStates.Visible;
                 try
                 {
                     Activity.RunOnUiThread(() => openNotification.ClickNotification());
                     if (openNotification.IsAutoCancellable())
                     {
-                        notification.Visibility = ViewStates.Invisible;
+                        WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = false, WidgetName = "NotificationFragment" });
+                        maincontainer.Visibility = ViewStates.Invisible;
                     }
                 }
                 catch
@@ -187,10 +234,11 @@ namespace LiveDisplay.Fragments
 
         private void ItemLongClicked(object sender, NotificationItemClickedEventArgs e)
         {
-            notification.Visibility = ViewStates.Visible;
+            maincontainer.Visibility = ViewStates.Visible;
             openNotification = new OpenNotification(e.StatusBarNotification);
             openNotification.Cancel();
-            notification.Visibility = ViewStates.Invisible;
+            WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = false, WidgetName = "NotificationFragment" });
+            maincontainer.Visibility = ViewStates.Invisible;
         }
 
         private void ItemClicked(object sender, NotificationItemClickedEventArgs e)
@@ -199,9 +247,9 @@ namespace LiveDisplay.Fragments
 
             //if the current notification widget does not have a tag, let's set it.
 
-            if (notification.GetTag(Resource.String.defaulttag) == null)
+            if (maincontainer.GetTag(Resource.String.defaulttag) == null)
             {
-                notification.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
+                maincontainer.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
             }
 
             if (configurationManager.RetrieveAValue(ConfigurationParameters.TestEnabled))
@@ -216,22 +264,23 @@ namespace LiveDisplay.Fragments
             //Only do this process if the notification that I want to show is different than the one that
             //the Notification Widget has.
             //If it's the same then simply show it.
-            if ((string)notification.GetTag(Resource.String.defaulttag) != openNotification.GetCustomId())
+            if ((string)maincontainer.GetTag(Resource.String.defaulttag) != openNotification.GetCustomId())
             {
                 styleApplier?.ApplyStyle(openNotification);
-                notification.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
-                if (notification.Visibility != ViewStates.Visible)
+                maincontainer.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
+                if (maincontainer.Visibility != ViewStates.Visible)
                 {
-                    notification.Visibility = ViewStates.Visible;
+                    WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "NotificationFragment" });
+                    maincontainer.Visibility = ViewStates.Visible;
                 }
             }
             else
             {
                 styleApplier?.ApplyStyle(openNotification);
-                notification.Visibility = ViewStates.Visible;
+                WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "NotificationFragment" });
+                maincontainer.Visibility = ViewStates.Visible;
             }
             StartTimeout(false);
-
         }
 
         #endregion Events Implementation:
@@ -241,32 +290,37 @@ namespace LiveDisplay.Fragments
         {
             //This action is: 'Hide the notification, and set the timeoutStarted as finished(false)
             //because this action will be invoked only when the timeout has finished.
-            void hideNotification() { if (notification != null) 
-                    notification.Visibility = ViewStates.Gone; 
-                timeoutStarted = false;
-                IsWidgetVisible?.Invoke(null, false);
-            }
+            
             //If the timeout has started, then cancel the action, and start again.
 
             if (stop)
             {
-                notification?.RemoveCallbacks(hideNotification); //Stop counting.
+                maincontainer?.RemoveCallbacks(HideNotification); //Stop counting.
                 return;
             }
             else
             {
                 if (timeoutStarted == true)
                 {
-                    notification?.RemoveCallbacks(hideNotification);
-                    notification?.PostDelayed(hideNotification,7000);
+                    maincontainer?.RemoveCallbacks(HideNotification);
+                    maincontainer?.PostDelayed(HideNotification,7000);
                 }
                 //If not, simply wait 5 seconds then hide the notification, in that span of time, the timeout is
                 //marked as Started(true)
                 else
                 {
                     timeoutStarted = true;
-                    notification?.PostDelayed(hideNotification, 7000);
+                    maincontainer?.PostDelayed(HideNotification, 7000);
                 }
+            }
+        }
+        void HideNotification()
+        {
+            if (maincontainer != null)
+            {
+                maincontainer.Visibility = ViewStates.Gone;
+                timeoutStarted = false;
+                WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = false, WidgetName = "NotificationFragment" });
             }
         }
     }

--- a/LiveDisplay/Fragments/NotificationFragment.cs
+++ b/LiveDisplay/Fragments/NotificationFragment.cs
@@ -34,21 +34,21 @@ namespace LiveDisplay.Fragments
         public override View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
         {
             View v = inflater.Inflate(Resource.Layout.NotificationFrag, container, false);
-            notification = v.FindViewById<LinearLayout>(Resource.Id.llNotification);
-            styleApplier = new NotificationStyleApplier(ref notification, this, NotificationViewType.OnLockscreen);
-            notification.Drag += Notification_Drag;
-            notification.Click += LlNotification_Click;
-            NotificationAdapterViewHolder.ItemClicked += ItemClicked;
-            NotificationAdapterViewHolder.ItemLongClicked += ItemLongClicked;
-            CatcherHelper.NotificationPosted += CatcherHelper_NotificationPosted;
-            CatcherHelper.NotificationRemoved += CatcherHelper_NotificationRemoved;
-            NotificationStyleApplier.SendInlineResponseAvailabityChanged += NotificationStyleApplier_SendInlineResponseAvailabityChanged;
+            notification = v.FindViewById<LinearLayout>(Resource.Id.container);
+            //styleApplier = new NotificationStyleApplier(ref notification, this, NotificationViewType.OnLockscreen);
+            //notification.Drag += Notification_Drag;
+            //notification.Click += LlNotification_Click;
+            //NotificationAdapterViewHolder.ItemClicked += ItemClicked;
+            //NotificationAdapterViewHolder.ItemLongClicked += ItemLongClicked;
+            //CatcherHelper.NotificationPosted += CatcherHelper_NotificationPosted;
+            //CatcherHelper.NotificationRemoved += CatcherHelper_NotificationRemoved;
+            //NotificationStyleApplier.SendInlineResponseAvailabityChanged += NotificationStyleApplier_SendInlineResponseAvailabityChanged;
 
-            if (openNotification == null) //We don't have a notification to show here, so...
-            {
-                //...Now ask Catcher to send us the last notification posted to fill the views..
-                NotificationSlave.NotificationSlaveInstance().RetrieveLastNotification();
-            }
+            //if (openNotification == null) //We don't have a notification to show here, so...
+            //{
+            //    //...Now ask Catcher to send us the last notification posted to fill the views..
+            //    NotificationSlave.NotificationSlaveInstance().RetrieveLastNotification();
+            //}
             return v;
         }
 
@@ -130,13 +130,13 @@ namespace LiveDisplay.Fragments
         }
         public override void OnDestroyView()
         {
-            notification.Drag -= Notification_Drag;
-            notification.Click -= LlNotification_Click;
-            NotificationAdapterViewHolder.ItemClicked -= ItemClicked;
-            NotificationAdapterViewHolder.ItemLongClicked -= ItemLongClicked;
-            CatcherHelper.NotificationRemoved -= CatcherHelper_NotificationRemoved;
-            CatcherHelper.NotificationPosted -= CatcherHelper_NotificationPosted;
-            NotificationStyleApplier.SendInlineResponseAvailabityChanged -= NotificationStyleApplier_SendInlineResponseAvailabityChanged;
+            //notification.Drag -= Notification_Drag;
+            //notification.Click -= LlNotification_Click;
+            //NotificationAdapterViewHolder.ItemClicked -= ItemClicked;
+            //NotificationAdapterViewHolder.ItemLongClicked -= ItemLongClicked;
+            //CatcherHelper.NotificationRemoved -= CatcherHelper_NotificationRemoved;
+            //CatcherHelper.NotificationPosted -= CatcherHelper_NotificationPosted;
+            //NotificationStyleApplier.SendInlineResponseAvailabityChanged -= NotificationStyleApplier_SendInlineResponseAvailabityChanged;
 
             styleApplier = null;
 

--- a/LiveDisplay/LiveDisplay.csproj
+++ b/LiveDisplay/LiveDisplay.csproj
@@ -48,6 +48,7 @@
     <AndroidLinkTool>r8</AndroidLinkTool>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidDexTool>dx</AndroidDexTool>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -375,6 +376,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateGeneratedFiles</Generator>
     </AndroidResource>
+    <AndroidResource Include="Resources\layout\MusicPlayer2.axml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateGeneratedFiles</Generator>
+    </AndroidResource>
     <AndroidResource Include="Resources\layout\NotificationItemRow.axml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateGeneratedFiles</Generator>
@@ -631,12 +636,6 @@
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\LockScreen2.xml">
-      <Generator>MSBuild:UpdateGeneratedFiles</Generator>
-      <SubType>Designer</SubType>
-    </AndroidResource>
-  </ItemGroup>
-  <ItemGroup>
-    <AndroidResource Include="Resources\layout\MusicPlayer2.axml">
       <Generator>MSBuild:UpdateGeneratedFiles</Generator>
       <SubType>Designer</SubType>
     </AndroidResource>

--- a/LiveDisplay/Misc/ConfigurationParameters.cs
+++ b/LiveDisplay/Misc/ConfigurationParameters.cs
@@ -49,5 +49,11 @@
 
         //toggles where to show a minitutorial to the user when it launches the lockscreen for the first time.
         public const string TutorialRead = "tutorialread?";
+
+        //Never used by the user: Which widget should be shown first when starting the lockscreen.
+        //By default it is the clock. (possible values: "clock", "music", "notification")
+        public const string StartingWidget = "clock";
+
+
     }
 }

--- a/LiveDisplay/Misc/PackageUtils.cs
+++ b/LiveDisplay/Misc/PackageUtils.cs
@@ -9,6 +9,8 @@ namespace LiveDisplay.Misc
 
         public static string GetTheAppName(string package)
         {
+            if (package == null) return string.Empty;
+
             ApplicationInfo applicationInfo = packageManager.GetApplicationInfo(package, 0); //Zero means: No specific PackageInfoFlags specified.
             package = packageManager.GetApplicationLabel(applicationInfo);
             return package;

--- a/LiveDisplay/Properties/AndroidManifest.xml
+++ b/LiveDisplay/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.underground.livedisplay" android:installLocation="auto" android:versionName="0.9.2-alpha1" android:versionCode="8">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.underground.livedisplay" android:installLocation="auto" android:versionName="0.9.2-beta1" android:versionCode="8">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" />

--- a/LiveDisplay/Resources/Resource.Designer.cs
+++ b/LiveDisplay/Resources/Resource.Designer.cs
@@ -2690,142 +2690,142 @@ namespace LiveDisplay
 			public const int collapseActionView = 2131230814;
 			
 			// aapt resource value: 0x7F08005F
-			public const int contenedorPrincipal = 2131230815;
+			public const int container = 2131230815;
 			
 			// aapt resource value: 0x7F080060
-			public const int content = 2131230816;
+			public const int contenedorPrincipal = 2131230816;
 			
 			// aapt resource value: 0x7F080061
-			public const int contentPanel = 2131230817;
+			public const int content = 2131230817;
+			
+			// aapt resource value: 0x7F080062
+			public const int contentPanel = 2131230818;
 			
 			// aapt resource value: 0x7F080001
 			public const int CTRL = 2131230721;
 			
-			// aapt resource value: 0x7F080062
-			public const int custom = 2131230818;
-			
 			// aapt resource value: 0x7F080063
-			public const int customPanel = 2131230819;
+			public const int custom = 2131230819;
 			
 			// aapt resource value: 0x7F080064
-			public const int decor_content_parent = 2131230820;
+			public const int customPanel = 2131230820;
 			
 			// aapt resource value: 0x7F080065
-			public const int default_activity_button = 2131230821;
+			public const int decor_content_parent = 2131230821;
 			
 			// aapt resource value: 0x7F080066
-			public const int deviceAccessCheckbox = 2131230822;
+			public const int default_activity_button = 2131230822;
 			
 			// aapt resource value: 0x7F080067
-			public const int dialog_button = 2131230823;
+			public const int deviceAccessCheckbox = 2131230823;
 			
 			// aapt resource value: 0x7F080068
-			public const int disableHome = 2131230824;
-			
-			// aapt resource value: 0x7F08006A
-			public const int drawOverlaysCheckboxContainer = 2131230826;
+			public const int dialog_button = 2131230824;
 			
 			// aapt resource value: 0x7F080069
-			public const int drawOverOtherAppsAccessCheckbox = 2131230825;
+			public const int disableHome = 2131230825;
 			
 			// aapt resource value: 0x7F08006B
-			public const int edit_query = 2131230827;
+			public const int drawOverlaysCheckboxContainer = 2131230827;
+			
+			// aapt resource value: 0x7F08006A
+			public const int drawOverOtherAppsAccessCheckbox = 2131230826;
 			
 			// aapt resource value: 0x7F08006C
-			public const int enableDeviceAccess = 2131230828;
+			public const int edit_query = 2131230828;
 			
 			// aapt resource value: 0x7F08006D
-			public const int enableFloatingPermission = 2131230829;
+			public const int enableDeviceAccess = 2131230829;
 			
 			// aapt resource value: 0x7F08006E
-			public const int enableNotificationAccess = 2131230830;
+			public const int enableFloatingPermission = 2131230830;
 			
 			// aapt resource value: 0x7F08006F
-			public const int end = 2131230831;
-			
-			// aapt resource value: 0x7F080071
-			public const int expanded_menu = 2131230833;
+			public const int enableNotificationAccess = 2131230831;
 			
 			// aapt resource value: 0x7F080070
-			public const int expand_activities_button = 2131230832;
+			public const int end = 2131230832;
 			
 			// aapt resource value: 0x7F080072
-			public const int forever = 2131230834;
+			public const int expanded_menu = 2131230834;
+			
+			// aapt resource value: 0x7F080071
+			public const int expand_activities_button = 2131230833;
 			
 			// aapt resource value: 0x7F080073
-			public const int fragment_container_view_tag = 2131230835;
+			public const int forever = 2131230835;
+			
+			// aapt resource value: 0x7F080074
+			public const int fragment_container_view_tag = 2131230836;
 			
 			// aapt resource value: 0x7F080002
 			public const int FUNCTION = 2131230722;
 			
-			// aapt resource value: 0x7F080074
-			public const int group_divider = 2131230836;
-			
 			// aapt resource value: 0x7F080075
-			public const int health = 2131230837;
+			public const int group_divider = 2131230837;
 			
 			// aapt resource value: 0x7F080076
-			public const int home = 2131230838;
+			public const int health = 2131230838;
 			
 			// aapt resource value: 0x7F080077
-			public const int homeAsUp = 2131230839;
+			public const int home = 2131230839;
 			
 			// aapt resource value: 0x7F080078
-			public const int humidity = 2131230840;
+			public const int homeAsUp = 2131230840;
 			
 			// aapt resource value: 0x7F080079
-			public const int icon = 2131230841;
+			public const int humidity = 2131230841;
 			
 			// aapt resource value: 0x7F08007A
-			public const int icon_frame = 2131230842;
+			public const int icon = 2131230842;
 			
 			// aapt resource value: 0x7F08007B
-			public const int icon_group = 2131230843;
+			public const int icon_frame = 2131230843;
 			
 			// aapt resource value: 0x7F08007C
-			public const int ifRoom = 2131230844;
+			public const int icon_group = 2131230844;
 			
 			// aapt resource value: 0x7F08007D
-			public const int image = 2131230845;
+			public const int ifRoom = 2131230845;
 			
 			// aapt resource value: 0x7F08007E
-			public const int info = 2131230846;
+			public const int image = 2131230846;
 			
 			// aapt resource value: 0x7F08007F
-			public const int inlineNotificationContainer = 2131230847;
+			public const int info = 2131230847;
 			
 			// aapt resource value: 0x7F080080
-			public const int italic = 2131230848;
+			public const int inlineNotificationContainer = 2131230848;
 			
 			// aapt resource value: 0x7F080081
-			public const int item_touch_helper_previous_elevation = 2131230849;
+			public const int italic = 2131230849;
 			
 			// aapt resource value: 0x7F080082
-			public const int ivNotificationIcon = 2131230850;
+			public const int item_touch_helper_previous_elevation = 2131230850;
 			
 			// aapt resource value: 0x7F080083
-			public const int lastupdated = 2131230851;
+			public const int ivNotificationIcon = 2131230851;
 			
 			// aapt resource value: 0x7F080084
-			public const int line1 = 2131230852;
+			public const int lastupdated = 2131230852;
 			
 			// aapt resource value: 0x7F080085
-			public const int line3 = 2131230853;
+			public const int line1 = 2131230853;
 			
 			// aapt resource value: 0x7F080086
-			public const int listMode = 2131230854;
+			public const int line3 = 2131230854;
 			
 			// aapt resource value: 0x7F080087
-			public const int list_item = 2131230855;
+			public const int listMode = 2131230855;
 			
 			// aapt resource value: 0x7F080088
-			public const int livedisplayinfo = 2131230856;
+			public const int list_item = 2131230856;
 			
 			// aapt resource value: 0x7F080089
-			public const int livesidplayinfoicon = 2131230857;
+			public const int livedisplayinfo = 2131230857;
 			
 			// aapt resource value: 0x7F08008A
-			public const int llNotification = 2131230858;
+			public const int livesidplayinfoicon = 2131230858;
 			
 			// aapt resource value: 0x7F08008B
 			public const int loadingblacklistitemsprogressbar = 2131230859;

--- a/LiveDisplay/Resources/Resource.Designer.cs
+++ b/LiveDisplay/Resources/Resource.Designer.cs
@@ -2909,277 +2909,283 @@ namespace LiveDisplay
 			public const int pickwallpaper = 2131230882;
 			
 			// aapt resource value: 0x7F0800A3
-			public const int progress_circular = 2131230883;
+			public const int playbackstatus = 2131230883;
 			
 			// aapt resource value: 0x7F0800A4
-			public const int progress_horizontal = 2131230884;
+			public const int progress_circular = 2131230884;
 			
 			// aapt resource value: 0x7F0800A5
-			public const int radio = 2131230885;
+			public const int progress_horizontal = 2131230885;
 			
 			// aapt resource value: 0x7F0800A6
-			public const int recycler_view = 2131230886;
+			public const int radio = 2131230886;
 			
 			// aapt resource value: 0x7F0800A7
-			public const int right_icon = 2131230887;
+			public const int recycler_view = 2131230887;
 			
 			// aapt resource value: 0x7F0800A8
-			public const int right_side = 2131230888;
+			public const int right_icon = 2131230888;
 			
 			// aapt resource value: 0x7F0800A9
-			public const int savesettings = 2131230889;
+			public const int right_side = 2131230889;
 			
 			// aapt resource value: 0x7F0800AA
-			public const int screen = 2131230890;
+			public const int savesettings = 2131230890;
 			
 			// aapt resource value: 0x7F0800AB
-			public const int scrollIndicatorDown = 2131230891;
+			public const int screen = 2131230891;
 			
 			// aapt resource value: 0x7F0800AC
-			public const int scrollIndicatorUp = 2131230892;
+			public const int scrollIndicatorDown = 2131230892;
 			
 			// aapt resource value: 0x7F0800AD
-			public const int scrollView = 2131230893;
-			
-			// aapt resource value: 0x7F0800B8
-			public const int searchboxapp = 2131230904;
+			public const int scrollIndicatorUp = 2131230893;
 			
 			// aapt resource value: 0x7F0800AE
-			public const int search_badge = 2131230894;
-			
-			// aapt resource value: 0x7F0800AF
-			public const int search_bar = 2131230895;
-			
-			// aapt resource value: 0x7F0800B0
-			public const int search_button = 2131230896;
-			
-			// aapt resource value: 0x7F0800B1
-			public const int search_close_btn = 2131230897;
-			
-			// aapt resource value: 0x7F0800B2
-			public const int search_edit_frame = 2131230898;
-			
-			// aapt resource value: 0x7F0800B3
-			public const int search_go_btn = 2131230899;
-			
-			// aapt resource value: 0x7F0800B4
-			public const int search_mag_icon = 2131230900;
-			
-			// aapt resource value: 0x7F0800B5
-			public const int search_plate = 2131230901;
-			
-			// aapt resource value: 0x7F0800B6
-			public const int search_src_text = 2131230902;
-			
-			// aapt resource value: 0x7F0800B7
-			public const int search_voice_btn = 2131230903;
+			public const int scrollView = 2131230894;
 			
 			// aapt resource value: 0x7F0800B9
-			public const int seekbar = 2131230905;
+			public const int searchboxapp = 2131230905;
+			
+			// aapt resource value: 0x7F0800AF
+			public const int search_badge = 2131230895;
+			
+			// aapt resource value: 0x7F0800B0
+			public const int search_bar = 2131230896;
+			
+			// aapt resource value: 0x7F0800B1
+			public const int search_button = 2131230897;
+			
+			// aapt resource value: 0x7F0800B2
+			public const int search_close_btn = 2131230898;
+			
+			// aapt resource value: 0x7F0800B3
+			public const int search_edit_frame = 2131230899;
+			
+			// aapt resource value: 0x7F0800B4
+			public const int search_go_btn = 2131230900;
+			
+			// aapt resource value: 0x7F0800B5
+			public const int search_mag_icon = 2131230901;
+			
+			// aapt resource value: 0x7F0800B6
+			public const int search_plate = 2131230902;
+			
+			// aapt resource value: 0x7F0800B7
+			public const int search_src_text = 2131230903;
+			
+			// aapt resource value: 0x7F0800B8
+			public const int search_voice_btn = 2131230904;
 			
 			// aapt resource value: 0x7F0800BA
-			public const int seekbar_value = 2131230906;
+			public const int seekbar = 2131230906;
 			
 			// aapt resource value: 0x7F0800BB
-			public const int seeksongTime = 2131230907;
+			public const int seekbar_value = 2131230907;
 			
 			// aapt resource value: 0x7F0800BC
-			public const int select_dialog_listview = 2131230908;
+			public const int seeksongTime = 2131230908;
 			
 			// aapt resource value: 0x7F0800BD
-			public const int sendInlineResponseButton = 2131230909;
+			public const int select_dialog_listview = 2131230909;
+			
+			// aapt resource value: 0x7F0800BE
+			public const int sendInlineResponseButton = 2131230910;
 			
 			// aapt resource value: 0x7F080006
 			public const int SHIFT = 2131230726;
 			
-			// aapt resource value: 0x7F0800BE
-			public const int shortcut = 2131230910;
-			
 			// aapt resource value: 0x7F0800BF
-			public const int shortcutcontainer = 2131230911;
+			public const int shortcut = 2131230911;
 			
 			// aapt resource value: 0x7F0800C0
-			public const int showCustom = 2131230912;
+			public const int shortcutcontainer = 2131230912;
 			
 			// aapt resource value: 0x7F0800C1
-			public const int showHome = 2131230913;
+			public const int showCustom = 2131230913;
 			
 			// aapt resource value: 0x7F0800C2
-			public const int showTitle = 2131230914;
+			public const int showHome = 2131230914;
 			
 			// aapt resource value: 0x7F0800C3
-			public const int spacer = 2131230915;
+			public const int showTitle = 2131230915;
 			
 			// aapt resource value: 0x7F0800C4
-			public const int spinner = 2131230916;
+			public const int sourceapp = 2131230916;
 			
 			// aapt resource value: 0x7F0800C5
-			public const int split_action_bar = 2131230917;
+			public const int spacer = 2131230917;
 			
 			// aapt resource value: 0x7F0800C6
-			public const int src_atop = 2131230918;
+			public const int spinner = 2131230918;
 			
 			// aapt resource value: 0x7F0800C7
-			public const int src_in = 2131230919;
+			public const int split_action_bar = 2131230919;
 			
 			// aapt resource value: 0x7F0800C8
-			public const int src_over = 2131230920;
+			public const int src_atop = 2131230920;
 			
 			// aapt resource value: 0x7F0800C9
-			public const int submenuarrow = 2131230921;
+			public const int src_in = 2131230921;
 			
 			// aapt resource value: 0x7F0800CA
-			public const int submit_area = 2131230922;
+			public const int src_over = 2131230922;
 			
 			// aapt resource value: 0x7F0800CB
-			public const int switchWidget = 2131230923;
+			public const int submenuarrow = 2131230923;
+			
+			// aapt resource value: 0x7F0800CC
+			public const int submit_area = 2131230924;
+			
+			// aapt resource value: 0x7F0800CD
+			public const int switchWidget = 2131230925;
 			
 			// aapt resource value: 0x7F080007
 			public const int SYM = 2131230727;
 			
-			// aapt resource value: 0x7F0800CC
-			public const int tabMode = 2131230924;
-			
-			// aapt resource value: 0x7F0800CD
-			public const int tag_accessibility_actions = 2131230925;
-			
 			// aapt resource value: 0x7F0800CE
-			public const int tag_accessibility_clickable_spans = 2131230926;
+			public const int tabMode = 2131230926;
 			
 			// aapt resource value: 0x7F0800CF
-			public const int tag_accessibility_heading = 2131230927;
+			public const int tag_accessibility_actions = 2131230927;
 			
 			// aapt resource value: 0x7F0800D0
-			public const int tag_accessibility_pane_title = 2131230928;
+			public const int tag_accessibility_clickable_spans = 2131230928;
 			
 			// aapt resource value: 0x7F0800D1
-			public const int tag_screen_reader_focusable = 2131230929;
+			public const int tag_accessibility_heading = 2131230929;
 			
 			// aapt resource value: 0x7F0800D2
-			public const int tag_transition_group = 2131230930;
+			public const int tag_accessibility_pane_title = 2131230930;
 			
 			// aapt resource value: 0x7F0800D3
-			public const int tag_unhandled_key_event_manager = 2131230931;
+			public const int tag_screen_reader_focusable = 2131230931;
 			
 			// aapt resource value: 0x7F0800D4
-			public const int tag_unhandled_key_listeners = 2131230932;
+			public const int tag_transition_group = 2131230932;
 			
 			// aapt resource value: 0x7F0800D5
-			public const int temperature = 2131230933;
+			public const int tag_unhandled_key_event_manager = 2131230933;
 			
 			// aapt resource value: 0x7F0800D6
-			public const int text = 2131230934;
+			public const int tag_unhandled_key_listeners = 2131230934;
 			
 			// aapt resource value: 0x7F0800D7
-			public const int text2 = 2131230935;
+			public const int temperature = 2131230935;
 			
 			// aapt resource value: 0x7F0800D8
-			public const int textSpacerNoButtons = 2131230936;
+			public const int text = 2131230936;
 			
 			// aapt resource value: 0x7F0800D9
-			public const int textSpacerNoTitle = 2131230937;
+			public const int text2 = 2131230937;
 			
 			// aapt resource value: 0x7F0800DA
-			public const int time = 2131230938;
+			public const int textSpacerNoButtons = 2131230938;
 			
 			// aapt resource value: 0x7F0800DB
-			public const int title = 2131230939;
+			public const int textSpacerNoTitle = 2131230939;
 			
 			// aapt resource value: 0x7F0800DC
-			public const int titleDividerNoCustom = 2131230940;
+			public const int time = 2131230940;
 			
 			// aapt resource value: 0x7F0800DD
-			public const int title_template = 2131230941;
+			public const int title = 2131230941;
 			
 			// aapt resource value: 0x7F0800DE
-			public const int toggleCollapse = 2131230942;
+			public const int titleDividerNoCustom = 2131230942;
 			
 			// aapt resource value: 0x7F0800DF
-			public const int toolbar = 2131230943;
+			public const int title_template = 2131230943;
 			
 			// aapt resource value: 0x7F0800E0
-			public const int top = 2131230944;
+			public const int toggleCollapse = 2131230944;
 			
 			// aapt resource value: 0x7F0800E1
-			public const int topPanel = 2131230945;
+			public const int toolbar = 2131230945;
 			
 			// aapt resource value: 0x7F0800E2
-			public const int tvAlbumName = 2131230946;
+			public const int top = 2131230946;
 			
 			// aapt resource value: 0x7F0800E3
-			public const int tvAppName = 2131230947;
+			public const int topPanel = 2131230947;
 			
 			// aapt resource value: 0x7F0800E4
-			public const int tvArtistName = 2131230948;
+			public const int tvAlbumName = 2131230948;
 			
 			// aapt resource value: 0x7F0800E5
-			public const int tvInlineText = 2131230949;
-			
-			// aapt resource value: 0x7F0800EA
-			public const int tvnotifSubtext = 2131230954;
+			public const int tvAppName = 2131230949;
 			
 			// aapt resource value: 0x7F0800E6
-			public const int tvSongName = 2131230950;
+			public const int tvArtistName = 2131230950;
 			
 			// aapt resource value: 0x7F0800E7
-			public const int tvText = 2131230951;
-			
-			// aapt resource value: 0x7F0800E8
-			public const int tvTitle = 2131230952;
-			
-			// aapt resource value: 0x7F0800E9
-			public const int tvWhen = 2131230953;
-			
-			// aapt resource value: 0x7F0800EB
-			public const int txtFechaLock = 2131230955;
+			public const int tvInlineText = 2131230951;
 			
 			// aapt resource value: 0x7F0800EC
-			public const int @unchecked = 2131230956;
+			public const int tvnotifSubtext = 2131230956;
+			
+			// aapt resource value: 0x7F0800E8
+			public const int tvSongName = 2131230952;
+			
+			// aapt resource value: 0x7F0800E9
+			public const int tvText = 2131230953;
+			
+			// aapt resource value: 0x7F0800EA
+			public const int tvTitle = 2131230954;
+			
+			// aapt resource value: 0x7F0800EB
+			public const int tvWhen = 2131230955;
 			
 			// aapt resource value: 0x7F0800ED
-			public const int uniform = 2131230957;
+			public const int txtFechaLock = 2131230957;
 			
 			// aapt resource value: 0x7F0800EE
-			public const int up = 2131230958;
-			
-			// aapt resource value: 0x7F0800F0
-			public const int useimperialsystem = 2131230960;
+			public const int @unchecked = 2131230958;
 			
 			// aapt resource value: 0x7F0800EF
-			public const int useLogo = 2131230959;
+			public const int uniform = 2131230959;
 			
-			// aapt resource value: 0x7F0800F1
-			public const int visible_removing_fragment_view_tag = 2131230961;
-			
-			// aapt resource value: 0x7F0800F3
-			public const int wallpaperbeingsetted = 2131230963;
+			// aapt resource value: 0x7F0800F0
+			public const int up = 2131230960;
 			
 			// aapt resource value: 0x7F0800F2
-			public const int wallpaperPreview = 2131230962;
+			public const int useimperialsystem = 2131230962;
 			
-			// aapt resource value: 0x7F0800F4
-			public const int weatherandcLockplaceholder = 2131230964;
+			// aapt resource value: 0x7F0800F1
+			public const int useLogo = 2131230961;
+			
+			// aapt resource value: 0x7F0800F3
+			public const int visible_removing_fragment_view_tag = 2131230963;
 			
 			// aapt resource value: 0x7F0800F5
-			public const int weatherclockcontainer = 2131230965;
+			public const int wallpaperbeingsetted = 2131230965;
+			
+			// aapt resource value: 0x7F0800F4
+			public const int wallpaperPreview = 2131230964;
 			
 			// aapt resource value: 0x7F0800F6
-			public const int weatherdescription = 2131230966;
+			public const int weatherandcLockplaceholder = 2131230966;
 			
 			// aapt resource value: 0x7F0800F7
-			public const int weatherupdatefrequency = 2131230967;
+			public const int weatherclockcontainer = 2131230967;
 			
 			// aapt resource value: 0x7F0800F8
-			public const int welcomeoverlay = 2131230968;
+			public const int weatherdescription = 2131230968;
+			
+			// aapt resource value: 0x7F0800F9
+			public const int weatherupdatefrequency = 2131230969;
+			
+			// aapt resource value: 0x7F0800FA
+			public const int welcomeoverlay = 2131230970;
 			
 			// aapt resource value: 0x7F080008
 			public const int WidgetPlaceholder = 2131230728;
 			
-			// aapt resource value: 0x7F0800F9
-			public const int withText = 2131230969;
+			// aapt resource value: 0x7F0800FB
+			public const int withText = 2131230971;
 			
-			// aapt resource value: 0x7F0800FA
-			public const int wrap_content = 2131230970;
+			// aapt resource value: 0x7F0800FC
+			public const int wrap_content = 2131230972;
 			
 			static Id()
 			{
@@ -3884,145 +3890,151 @@ namespace LiveDisplay
 			public const int not_set = 2131624051;
 			
 			// aapt resource value: 0x7F0E0077
-			public const int ok = 2131624055;
+			public const int now_playing = 2131624055;
 			
 			// aapt resource value: 0x7F0E0078
-			public const int onehour = 2131624056;
+			public const int ok = 2131624056;
 			
 			// aapt resource value: 0x7F0E0079
-			public const int opciones = 2131624057;
+			public const int onehour = 2131624057;
 			
 			// aapt resource value: 0x7F0E007A
-			public const int partiallyblocked = 2131624058;
+			public const int opciones = 2131624058;
 			
 			// aapt resource value: 0x7F0E007B
-			public const int pickwallpaper = 2131624059;
+			public const int partiallyblocked = 2131624059;
 			
 			// aapt resource value: 0x7F0E007C
-			public const int placeholder = 2131624060;
+			public const int pickwallpaper = 2131624060;
 			
 			// aapt resource value: 0x7F0E007D
-			public const int preference_copied = 2131624061;
+			public const int placeholder = 2131624061;
 			
 			// aapt resource value: 0x7F0E007E
-			public const int rus = 2131624062;
+			public const int playing_from_template = 2131624062;
 			
 			// aapt resource value: 0x7F0E007F
-			public const int saveweathersettings = 2131624063;
-			
-			// aapt resource value: 0x7F0E0081
-			public const int searchappedittexthint = 2131624065;
-			
-			// aapt resource value: 0x7F0E0082
-			public const int searchapptitle = 2131624066;
+			public const int preference_copied = 2131624063;
 			
 			// aapt resource value: 0x7F0E0080
-			public const int search_menu_title = 2131624064;
+			public const int rus = 2131624064;
+			
+			// aapt resource value: 0x7F0E0081
+			public const int saveweathersettings = 2131624065;
 			
 			// aapt resource value: 0x7F0E0083
-			public const int secretmessagehint = 2131624067;
+			public const int searchappedittexthint = 2131624067;
 			
 			// aapt resource value: 0x7F0E0084
-			public const int secretmessageplaceholder = 2131624068;
+			public const int searchapptitle = 2131624068;
+			
+			// aapt resource value: 0x7F0E0082
+			public const int search_menu_title = 2131624066;
 			
 			// aapt resource value: 0x7F0E0085
-			public const int sendtestnotification = 2131624069;
+			public const int secretmessagehint = 2131624069;
 			
 			// aapt resource value: 0x7F0E0086
-			public const int settings = 2131624070;
+			public const int secretmessageplaceholder = 2131624070;
 			
 			// aapt resource value: 0x7F0E0087
-			public const int showalbumart = 2131624071;
+			public const int sendtestnotification = 2131624071;
 			
 			// aapt resource value: 0x7F0E0088
-			public const int sixhours = 2131624072;
+			public const int settings = 2131624072;
 			
 			// aapt resource value: 0x7F0E0089
-			public const int status_bar_notification_info_overflow = 2131624073;
+			public const int showalbumart = 2131624073;
 			
 			// aapt resource value: 0x7F0E008A
-			public const int summary_collapsed_preference_list = 2131624074;
+			public const int sixhours = 2131624074;
 			
 			// aapt resource value: 0x7F0E008B
-			public const int tenseconds = 2131624075;
+			public const int status_bar_notification_info_overflow = 2131624075;
 			
 			// aapt resource value: 0x7F0E008C
-			public const int testnotificationtext = 2131624076;
+			public const int summary_collapsed_preference_list = 2131624076;
 			
 			// aapt resource value: 0x7F0E008D
-			public const int thirtyminutes = 2131624077;
+			public const int tenseconds = 2131624077;
 			
 			// aapt resource value: 0x7F0E008E
-			public const int translations = 2131624078;
+			public const int testnotificationtext = 2131624078;
 			
 			// aapt resource value: 0x7F0E008F
-			public const int turnoffdelay = 2131624079;
+			public const int thirtyminutes = 2131624079;
 			
 			// aapt resource value: 0x7F0E0090
-			public const int turnoffdelay_desc = 2131624080;
+			public const int translations = 2131624080;
 			
 			// aapt resource value: 0x7F0E0091
-			public const int turnoffscreenafterlastnotificationcleared = 2131624081;
+			public const int turnoffdelay = 2131624081;
 			
 			// aapt resource value: 0x7F0E0092
-			public const int turnonnewnotification = 2131624082;
+			public const int turnoffdelay_desc = 2131624082;
 			
 			// aapt resource value: 0x7F0E0093
-			public const int turnonnewnotification_desc = 2131624083;
+			public const int turnoffscreenafterlastnotificationcleared = 2131624083;
 			
 			// aapt resource value: 0x7F0E0094
-			public const int turnonusermovement = 2131624084;
+			public const int turnonnewnotification = 2131624084;
 			
 			// aapt resource value: 0x7F0E0095
-			public const int tutorialtext = 2131624085;
+			public const int turnonnewnotification_desc = 2131624085;
 			
 			// aapt resource value: 0x7F0E0096
-			public const int twelvehours = 2131624086;
+			public const int turnonusermovement = 2131624086;
 			
 			// aapt resource value: 0x7F0E0097
-			public const int updateweathereach = 2131624087;
+			public const int tutorialtext = 2131624087;
 			
 			// aapt resource value: 0x7F0E0098
-			public const int useimperialunits = 2131624088;
+			public const int twelvehours = 2131624088;
 			
 			// aapt resource value: 0x7F0E0099
-			public const int v7_preference_off = 2131624089;
+			public const int updateweathereach = 2131624089;
 			
 			// aapt resource value: 0x7F0E009A
-			public const int v7_preference_on = 2131624090;
+			public const int useimperialunits = 2131624090;
 			
 			// aapt resource value: 0x7F0E009B
-			public const int version = 2131624091;
+			public const int v7_preference_off = 2131624091;
 			
 			// aapt resource value: 0x7F0E009C
-			public const int versionnumber = 2131624092;
+			public const int v7_preference_on = 2131624092;
 			
 			// aapt resource value: 0x7F0E009D
-			public const int wallpaperblur = 2131624093;
+			public const int version = 2131624093;
 			
 			// aapt resource value: 0x7F0E009E
-			public const int wallpaperopacity = 2131624094;
+			public const int versionnumber = 2131624094;
 			
 			// aapt resource value: 0x7F0E009F
-			public const int wallpapersettingappliestoalbumart = 2131624095;
+			public const int wallpaperblur = 2131624095;
 			
 			// aapt resource value: 0x7F0E00A0
-			public const int wallpapersettings = 2131624096;
+			public const int wallpaperopacity = 2131624096;
 			
 			// aapt resource value: 0x7F0E00A1
-			public const int weather = 2131624097;
+			public const int wallpapersettingappliestoalbumart = 2131624097;
 			
 			// aapt resource value: 0x7F0E00A2
-			public const int weatherwidget = 2131624098;
+			public const int wallpapersettings = 2131624098;
 			
 			// aapt resource value: 0x7F0E00A3
-			public const int weatherwidgetenabled = 2131624099;
+			public const int weather = 2131624099;
 			
 			// aapt resource value: 0x7F0E00A4
-			public const int yasujizr = 2131624100;
+			public const int weatherwidget = 2131624100;
 			
 			// aapt resource value: 0x7F0E00A5
-			public const int yasujizr_ty = 2131624101;
+			public const int weatherwidgetenabled = 2131624101;
+			
+			// aapt resource value: 0x7F0E00A6
+			public const int yasujizr = 2131624102;
+			
+			// aapt resource value: 0x7F0E00A7
+			public const int yasujizr_ty = 2131624103;
 			
 			static String()
 			{

--- a/LiveDisplay/Resources/layout/MusicPlayer2.axml
+++ b/LiveDisplay/Resources/layout/MusicPlayer2.axml
@@ -5,16 +5,17 @@
     android:layout_gravity="bottom"
     android:gravity="bottom"
     android:orientation="vertical"
+    android:visibility="invisible"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
     <TextView
+        android:id="@+id/playbackstatus"
         android:paddingRight="30dp"
         android:alpha="0.5"
-        android:text="Now playing"
+        android:text="@string/now_playing"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
     <TextView
-        android:text="Breathe"
 		android:paddingRight="30dp"
 		android:textSize="25dp"
         android:fontFamily="sans-serif-condensed"
@@ -24,7 +25,6 @@
         android:textColor="@color/primary_text_default_material_dark"
         android:textStyle="normal" />
     <TextView
-        android:text="Levianth"
 		android:paddingRight="30dp"
 		android:textSize="19dp"
         android:fontFamily="sans-serif-condensed"
@@ -34,7 +34,6 @@
         android:textColor="@color/primary_text_default_material_dark"
         android:textStyle="normal" />
     <TextView
-        android:text="Breathe"
 		android:paddingRight="30dp"
 	    android:textSize="17dp"
         android:fontFamily="sans-serif-condensed"
@@ -51,9 +50,9 @@
         android:layout_height="wrap_content"
         android:id="@+id/seeksongTime" />
     <TextView
+        android:id="@+id/sourceapp"
         android:paddingRight="30dp"
         android:alpha="0.5"
-        android:text="From Spotify"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
     <LinearLayout

--- a/LiveDisplay/Resources/layout/MusicPlayer2.axml
+++ b/LiveDisplay/Resources/layout/MusicPlayer2.axml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/musicPlayerContainer"
+    android:id="@+id/container"
     android:animateLayoutChanges="true"
     android:layout_gravity="bottom"
     android:gravity="bottom"
@@ -14,6 +14,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"/>
     <TextView
+        android:text="Breathe"
 		android:paddingRight="30dp"
 		android:textSize="25dp"
         android:fontFamily="sans-serif-condensed"
@@ -23,6 +24,7 @@
         android:textColor="@color/primary_text_default_material_dark"
         android:textStyle="normal" />
     <TextView
+        android:text="Levianth"
 		android:paddingRight="30dp"
 		android:textSize="19dp"
         android:fontFamily="sans-serif-condensed"
@@ -32,6 +34,7 @@
         android:textColor="@color/primary_text_default_material_dark"
         android:textStyle="normal" />
     <TextView
+        android:text="Breathe"
 		android:paddingRight="30dp"
 	    android:textSize="17dp"
         android:fontFamily="sans-serif-condensed"

--- a/LiveDisplay/Resources/layout/NotificationFrag.xml
+++ b/LiveDisplay/Resources/layout/NotificationFrag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/llNotification"
+    android:id="@+id/container"
     android:layout_gravity="bottom"
     android:animateLayoutChanges="true"
     android:orientation="vertical"
@@ -10,7 +10,7 @@
     android:minHeight="70dp"
     android:background="?android:selectableItemBackground"
     tools:visibility="visible"
-    android:visibility="invisible">
+    android:visibility="visible">
 	
     <LinearLayout
 		android:weightSum="10"
@@ -23,7 +23,7 @@
 			android:layout_weight="8"
 			android:layout_height="wrap_content">
 			<TextView
-				tools:text="Spotify"
+				android:text="Spotify"
 				android:fontFamily="sans-serif-condensed"
 				android:textColor="@color/primary_text_default_material_dark"
 				android:textStyle="italic"
@@ -35,7 +35,7 @@
 				android:layout_width="3dp"
 				android:layout_height="wrap_content" />
 			<TextView
-				tools:text="8:13 PM"
+				android:text="8:13 PM"
 				android:fontFamily="sans-serif-condensed"
 				android:textAppearance="?android:attr/textAppearanceSmall"
 				android:textColor="@color/primary_text_default_material_dark"
@@ -48,7 +48,7 @@
                 android:layout_width="3dp"
                 android:layout_height="wrap_content"/>
             <TextView
-				tools:text="Trap Workout"
+				android:text="Trap Workout"
                 android:fontFamily="sans-serif-condensed"
                 android:textSize="16dp"
                 android:id="@+id/tvnotifSubtext"
@@ -73,7 +73,7 @@
     </LinearLayout>
     <TextView
 		android:textSize="22dp"
-		tools:text="One by One - Hunter Siegel Remix"
+		android:text="One by One - Hunter Siegel Remix"
         android:fontFamily="sans-serif-condensed"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="@color/primary_text_default_material_dark"
@@ -81,7 +81,7 @@
         android:layout_height="wrap_content"
         android:id="@+id/tvTitle" />
     <TextView
-		tools:text="GG Magree, Hunter Segel"
+		android:text="GG Magree, Hunter Segel"
         android:fontFamily="sans-serif-condensed"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="@color/primary_text_default_material_dark"

--- a/LiveDisplay/Resources/layout/NotificationFrag.xml
+++ b/LiveDisplay/Resources/layout/NotificationFrag.xml
@@ -10,7 +10,7 @@
     android:minHeight="70dp"
     android:background="?android:selectableItemBackground"
     tools:visibility="visible"
-    android:visibility="visible">
+    android:visibility="invisible">
 	
     <LinearLayout
 		android:weightSum="10"

--- a/LiveDisplay/Resources/layout/cLock2.xml
+++ b/LiveDisplay/Resources/layout/cLock2.xml
@@ -5,6 +5,8 @@
     a:layout_height="match_parent"
 	a:id="@+id/container"
 	a:orientation="vertical"
+	tools:visibility="visible"
+	a:visibility="invisible"
     a:gravity="bottom">
 	<!--<LinearLayout
 		a:id="@+id/weatherinfo"

--- a/LiveDisplay/Resources/layout/cLock2.xml
+++ b/LiveDisplay/Resources/layout/cLock2.xml
@@ -3,7 +3,7 @@
 	xmlns:tools="http://schemas.android.com/tools"
     a:layout_width="match_parent"
     a:layout_height="match_parent"
-	a:id="@+id/weatherclockcontainer"
+	a:id="@+id/container"
 	a:orientation="vertical"
     a:gravity="bottom">
 	<!--<LinearLayout

--- a/LiveDisplay/Resources/values-es/Strings.xml
+++ b/LiveDisplay/Resources/values-es/Strings.xml
@@ -86,12 +86,14 @@
   <string name="notavailableyet">No disponible...aún.</string>
   <string name="notificationsettings">Notificaciones</string>
   <string name="notificationviewvisibilitytime">Después de clicar la notificación esconderla después de...</string>
+  <string name="now_playing">Reproduciendo Ahora:</string>
   <string name="ok">Ok</string>
   <string name="onehour">1 Hora</string>
   <string name="opciones">Opciones</string>
   <string name="partiallyblocked">Solo en la app</string>
   <string name="pickwallpaper">Elige uno</string>
   <string name="placeholder">Inserta una cadena aquí</string>
+  <string name="playing_from_template">Desde {0}</string>
   <string name="rus">Ruso</string>
   <string name="saveweathersettings">Guardar</string>
   <string name="searchappedittexthint">Nombre de la app...</string>

--- a/LiveDisplay/Resources/values-ro/Strings.xml
+++ b/LiveDisplay/Resources/values-ro/Strings.xml
@@ -23,8 +23,10 @@
   <string name="musicwidgetenabled">Activează Widget de Muzică</string>
   <string name="notavailableyet">Nu este disponibil încă ...</string>
   <string name="notificationsettings">Notificări</string>
+  <string name="now_playing">Acum Jucăm:</string>
   <string name="onehour">1 oră</string>
   <string name="opciones">Opțiuni</string>
+  <string name="playing_from_template">Din {0}</string>
   <string name="saveweathersettings">Salvați</string>
   <string name="showalbumart">Arată coperta albumului</string>
   <string name="sixhours">6 ore</string>

--- a/LiveDisplay/Resources/values/Strings.xml
+++ b/LiveDisplay/Resources/values/Strings.xml
@@ -89,12 +89,14 @@
   <string name="notavailableyet">Not available... yet.</string>
   <string name="notificationsettings">Notifications</string>
   <string name="notificationviewvisibilitytime">After clicking the notification hide it after...</string>
+  <string name="now_playing">Now Playing:</string>
   <string name="ok">Ok</string>
   <string name="onehour">1 Hour</string>
   <string name="opciones">Options</string>
   <string name="partiallyblocked">Block only in the app</string>
   <string name="pickwallpaper">Pick one</string>
   <string name="placeholder">Insert a string here</string>
+  <string name="playing_from_template">From {0}</string>
   <string name="rus">Russian</string>
   <string name="saveweathersettings">Save</string>
   <string name="searchappedittexthint">App name...</string>
@@ -120,7 +122,7 @@
   <string name="updateweathereach">Update weather each:</string>
   <string name="useimperialunits">Use Imperial units</string>
   <string name="version">Version</string>
-  <string name="versionnumber">0.9.2-alpha1</string>
+  <string name="versionnumber">0.9.2-beta1</string>
   <string name="wallpaperblur">Blur</string>
   <string name="wallpaperopacity">Opacity</string>
   <string name="wallpapersettingappliestoalbumart">Current setting also affects album artwork</string>

--- a/LiveDisplay/Servicios/Music/ActiveMediaSessionsListener.cs
+++ b/LiveDisplay/Servicios/Music/ActiveMediaSessionsListener.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Media.Session;
 using LiveDisplay.Misc;
+using LiveDisplay.Servicios.Widget;
 using System.Collections.Generic;
 
 namespace LiveDisplay.Servicios.Music
@@ -24,6 +25,8 @@ namespace LiveDisplay.Servicios.Music
                             try
                             {
                                 MusicController.StartPlayback(mediacontroller.SessionToken);
+                                WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "MusicFragment", Active=true });
+                                
                             }
                             catch
                             {

--- a/LiveDisplay/Servicios/Music/MediaEventArgs/MediaMetadataChangedEventArgs.cs
+++ b/LiveDisplay/Servicios/Music/MediaEventArgs/MediaMetadataChangedEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿using Android.App;
 using Android.Media;
+using Android.Net.Wifi.Aware;
 using System;
 
 namespace LiveDisplay.Servicios.Music.MediaEventArgs
@@ -8,5 +9,6 @@ namespace LiveDisplay.Servicios.Music.MediaEventArgs
     {
         public MediaMetadata MediaMetadata { get; set; }
         public PendingIntent ActivityIntent { get; set; }
+        public string AppName { get; set; }
     }
 }

--- a/LiveDisplay/Servicios/Music/MusicController.cs
+++ b/LiveDisplay/Servicios/Music/MusicController.cs
@@ -29,6 +29,7 @@ namespace LiveDisplay.Servicios.Music
         private static MediaController _currentMediaController;
         private static MediaSession.Token _currentToken;
         private static bool _playbackstarted;
+        private static string _appname;
 
         #region events
 
@@ -99,6 +100,7 @@ namespace LiveDisplay.Servicios.Music
                 _mediaMetadata = controller.Metadata;
                 _playbackState = controller.PlaybackState;
                 _activityIntent = controller.SessionActivity;
+                _appname = PackageUtils.GetTheAppName(controller.PackageName);
             }
             Jukebox.MediaEvent += Jukebox_MediaEvent;
         }
@@ -144,7 +146,8 @@ namespace LiveDisplay.Servicios.Music
                     OnMediaMetadataChanged(new MediaMetadataChangedEventArgs
                     {
                         MediaMetadata = _mediaMetadata,
-                        ActivityIntent = _activityIntent
+                        ActivityIntent = _activityIntent,
+                        AppName= _appname
                     });
                     //Send Playbackstate of the media.
                     OnMediaPlaybackChanged(new MediaPlaybackStateChangedEventArgs
@@ -179,7 +182,8 @@ namespace LiveDisplay.Servicios.Music
             OnMediaMetadataChanged(new MediaMetadataChangedEventArgs
             {
                 ActivityIntent = _activityIntent,
-                MediaMetadata = _mediaMetadata
+                MediaMetadata = _mediaMetadata,
+                AppName= _appname
             });
             //Datos de la Media que se está reproduciendo.
 

--- a/LiveDisplay/Servicios/Music/MusicControllerKitkat.cs
+++ b/LiveDisplay/Servicios/Music/MusicControllerKitkat.cs
@@ -3,6 +3,7 @@ using Android.Util;
 using Android.Views;
 using LiveDisplay.Misc;
 using LiveDisplay.Servicios.Music.MediaEventArgs;
+using LiveDisplay.Servicios.Widget;
 using System;
 
 namespace LiveDisplay.Servicios.Music
@@ -16,6 +17,8 @@ namespace LiveDisplay.Servicios.Music
     internal class MusicControllerKitkat : IDisposable
     {
         private static MusicControllerKitkat instance;
+
+        private bool requestedWidgetStart = false;
 
         public static RemoteControlPlayState MusicStatus { get; private set; }
         public RemoteControlPlayState PlaybackState { get; set; }
@@ -126,6 +129,11 @@ namespace LiveDisplay.Servicios.Music
             switch (state)
             {
                 case RemoteControlPlayState.Playing:
+                    if (requestedWidgetStart == false)
+                    {
+                        WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = true, WidgetName = "MusicFragment", Active=true });
+                        requestedWidgetStart = true;
+                    }
                     MusicPlaying?.Invoke(null, EventArgs.Empty);
                     break;
 
@@ -145,7 +153,7 @@ namespace LiveDisplay.Servicios.Music
                 Album = mediaMetadata.GetString((MediaMetadataEditKey)MetadataKey.Album, ""),
                 AlbumArt = mediaMetadata.GetBitmap(MediaMetadataEditKey.BitmapKeyArtwork, null),
                 Duration = mediaMetadata.GetLong((MediaMetadataEditKey)MetadataKey.Duration, 0)
-            });
+            });            
         }
 
         #region Raising events.

--- a/LiveDisplay/Servicios/Notificaciones/NotificationStyle/NotificationStyleApplier.cs
+++ b/LiveDisplay/Servicios/Notificaciones/NotificationStyle/NotificationStyleApplier.cs
@@ -10,6 +10,7 @@ using Android.Views.InputMethods;
 using Android.Widget;
 using LiveDisplay.Misc;
 using LiveDisplay.Servicios.Wallpaper;
+using LiveDisplay.Servicios.Widget;
 using System;
 
 namespace LiveDisplay.Servicios.Notificaciones.NotificationStyle
@@ -225,6 +226,7 @@ namespace LiveDisplay.Servicios.Notificaciones.NotificationStyle
             OpenNotification openNotification = closenotificationbutton.GetTag(DefaultActionIdentificator) as OpenNotification;
             openNotification.Cancel();
             notificationView.SetTag(Resource.String.defaulttag, openNotification.GetCustomId());
+            WidgetStatusPublisher.RequestShow(new WidgetStatusEventArgs { Show = false, WidgetName = "NotificationFragment" }); 
             notificationView.Visibility = ViewStates.Invisible;
         }
 

--- a/LiveDisplay/Servicios/Widget/WidgetStatusPublisher.cs
+++ b/LiveDisplay/Servicios/Widget/WidgetStatusPublisher.cs
@@ -14,42 +14,29 @@ using Android.Widget;
 namespace LiveDisplay.Servicios.Widget
 {
     //Widgets (fragments) should invoke the event! always, the reason is that lockscreen has to know the state of all the widgets.
-    //in order to replace them and stuff.
+    //in order to show/hide them.
     public class WidgetStatusPublisher
     {
+        public static string CurrentActiveWidget = string.Empty;
         private static List<WidgetStatusEventArgs> AllWidgetsStatuses= new List<WidgetStatusEventArgs>();
         public static event EventHandler<WidgetStatusEventArgs> OnWidgetStatusChanged;
 
-        public static void NotifyWidgetStatus(WidgetStatusEventArgs e)
-        {            
-            var match = AllWidgetsStatuses.Where(x => x.WidgetName == e.WidgetName).FirstOrDefault();
-            if (match != null)
-            {
-                AllWidgetsStatuses.Remove(match);
-                AllWidgetsStatuses.Add(e); //Update.
-            }
-            else 
-            {
-                AllWidgetsStatuses.Add(e);
-            }
+        public static void RequestShow(WidgetStatusEventArgs e)
+        {
+            if (e.Active)
+                CurrentActiveWidget = e.WidgetName;
+            else {
+                CurrentActiveWidget = string.Empty;}
 
             OnWidgetStatusChanged?.Invoke(null, e);
         }
-        public static WidgetStatusEventArgs.WidgetStatus? GetWidgetStatus(string nameOfWidget)
-        {
-            return AllWidgetsStatuses?.Where(x => x.WidgetName == nameOfWidget).FirstOrDefault()?.Status;
-        }
+
     }
     public class WidgetStatusEventArgs : EventArgs
     {
         public string WidgetName { get; set; }
-        public WidgetStatus Status { get; set; }
-        public enum WidgetStatus
-        {
-            Unknown = 0,
-            Present = 1,
-            NonPresent = 2,
-            Active= 4 //Should be constantly shown
-        }
+        public bool Show { get; set; }
+        public bool Active { get; set; } //It means that if a widget says it is active then 
+        //any other widget replacing this one should disappear asap and call RequestShow(CurrentActiveWidget), so the active widget regains control.
     }
 }


### PR DESCRIPTION
Replacing Standard Android method of 'Replace and commit' because it was affecting the performance of the app. (Specially in Music Widget)
This method here uses tricks to Show/Hide overlapping Fragments to give the illusion of Replacing as Android does when using FragmentManager.
This made FloatingNotification as it is, obsolete (could be used for other cool things) It was tested and it works, in order to continue with other app aspects.
